### PR TITLE
fix(copy): add specific functions for copying files vs folders

### DIFF
--- a/pollination/path/copy.py
+++ b/pollination/path/copy.py
@@ -11,7 +11,7 @@ class Copy(Function):
     )
 
     @command
-    def copy_file(self):
+    def copy_path(self):
         return 'echo copying input path...'
 
     dst = Outputs.path(
@@ -28,7 +28,7 @@ class CopyMultiple(Function):
     )
 
     @command
-    def copy_file(self):
+    def copy_path(self):
         return 'echo copying input path...'
 
     dst_1 = Outputs.path(description='Output 1 file or folder.', path='input_path')
@@ -42,3 +42,87 @@ class CopyMultiple(Function):
     dst_5 = Outputs.path(description='Output 5 file or folder.', path='input_path')
 
     dst_6 = Outputs.path(description='Output 6 file or folder.', path='input_path')
+
+
+@dataclass
+class CopyFile(Function):
+    """Copy a file to a destination."""
+
+    src = Inputs.file(
+        description='Path to a input file.', path='input.path'
+    )
+
+    @command
+    def copy_file(self):
+        return 'echo copying input file...'
+
+    dst = Outputs.file(
+        description='Output file.', path='input.path'
+    )
+
+
+@dataclass
+class CopyFileMultiple(Function):
+    """Copy a file to multiple destinations."""
+
+    src = Inputs.file(
+        description='Path to a input file.', path='input.path'
+    )
+
+    @command
+    def copy_file(self):
+        return 'echo copying input path...'
+
+    dst_1 = Outputs.file(description='Output 1 file.', path='input.path')
+
+    dst_2 = Outputs.file(description='Output 2 file.', path='input.path')
+
+    dst_3 = Outputs.file(description='Output 3 file.', path='input.path')
+
+    dst_4 = Outputs.file(description='Output 4 file.', path='input.path')
+
+    dst_5 = Outputs.file(description='Output 5 file.', path='input.path')
+
+    dst_6 = Outputs.file(description='Output 6 file.', path='input.path')
+
+
+@dataclass
+class CopyFolder(Function):
+    """Copy a folder to a destination."""
+
+    src = Inputs.folder(
+        description='Path to a input folder.', path='input.path'
+    )
+
+    @command
+    def copy_folder(self):
+        return 'echo copying input folder...'
+
+    dst = Outputs.folder(
+        description='Output folder.', path='input.path'
+    )
+
+
+@dataclass
+class CopyFolderMultiple(Function):
+    """Copy a folder to multiple destinations."""
+
+    src = Inputs.folder(
+        description='Path to a input folder.', path='input.path'
+    )
+
+    @command
+    def copy_folder(self):
+        return 'echo copying input path...'
+
+    dst_1 = Outputs.folder(description='Output 1 folder.', path='input.path')
+
+    dst_2 = Outputs.folder(description='Output 2 folder.', path='input.path')
+
+    dst_3 = Outputs.folder(description='Output 3 folder.', path='input.path')
+
+    dst_4 = Outputs.folder(description='Output 4 folder.', path='input.path')
+
+    dst_5 = Outputs.folder(description='Output 5 folder.', path='input.path')
+
+    dst_6 = Outputs.folder(description='Output 6 folder.', path='input.path')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pollination-dsl==0.12.3
+pollination-dsl==0.14.1


### PR DESCRIPTION
The distinction becomes important for translating the copy commands to shell commands successfully.


cc: @chriswmackey and @pollination/radiance-developers - we should start replacing the `Copy`, and `CopyMultiple` functions with `CopyFile` and `CopyFolder` functions whenever possible.